### PR TITLE
event: added support for priority only events

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -22,6 +22,7 @@
 #define EVENT_ASSERT(expr)
 #endif
 
+#define EVENT_EPOLL_PRIORITY            (EPOLLPRI)
 #define EVENT_EPOLL_READ                (EPOLLIN | EPOLLPRI)
 #define EVENT_EPOLL_WRITE               (EPOLLOUT)
 #ifdef EPOLLRDHUP    /* Since Linux 2.6.17 */
@@ -55,6 +56,9 @@ static uint32_t event_mask_to_epoll_events(uint32_t events)
     if (events & EVENT_IO_READ) {
         mask |= EVENT_EPOLL_READ;
     }
+    if (events & EVENT_IO_PRIORITY) {
+        mask |= EVENT_EPOLL_PRIORITY;
+    }
     if (events & EVENT_IO_WRITE) {
         mask |= EVENT_EPOLL_WRITE;
     }
@@ -73,6 +77,9 @@ static uint32_t event_mask_from_epoll_events(uint32_t events)
 
     if (events & EVENT_EPOLL_READ) {
         mask |= EVENT_IO_READ;
+    }
+    if (events & EVENT_EPOLL_PRIORITY) {
+        mask |= EVENT_IO_PRIORITY;
     }
     if (events & EVENT_EPOLL_WRITE) {
         mask |= EVENT_IO_WRITE;

--- a/src/event.h
+++ b/src/event.h
@@ -26,7 +26,8 @@ struct epoll_event;
 enum event_io_type {
     EVENT_IO_READ               = 0x01,
     EVENT_IO_WRITE              = 0x02,
-    EVENT_IO_DISCONNECT         = 0x04
+    EVENT_IO_DISCONNECT         = 0x04,
+    EVENT_IO_PRIORITY           = 0x08
 };
 
 struct event_context;


### PR DESCRIPTION
* Priority only events are needed to support Linux gpiolib events